### PR TITLE
Add requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+xarray
+matplotlib
+numpy
+cartopy
+netCDF4
+h5netcdf


### PR DESCRIPTION
Running the notebook had some missing requirements - [netcdf, h5netcdf].  
Created a requirements.txt file and added all the requirements in the notebook including the missing ones so that Github code workspaces automatically installs the requirements after setup